### PR TITLE
go.mod: fix module name to absolute url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/google/regexpand
 
 go 1.23
 
-require github.com/google/go-cmp v0.6.0
+require github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module regexpand
+module github.com/google/regexpand
 
 go 1.23
 

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/regexpand_example_test.go
+++ b/regexpand_example_test.go
@@ -16,7 +16,8 @@ package regexpand_test
 
 import (
 	"fmt"
-	"regexpand"
+
+	"github.com/google/regexpand"
 )
 
 func ExampleExpand() {


### PR DESCRIPTION
Fix module name to absolute url that is `github.com/google/regexpand`.